### PR TITLE
Support #39 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ If using a collection to produce `<select>` `<option>`s, the following may also 
 - `[textAttribute]`: model attribute to use as the text of the option node in the select box
 - `[yieldModel]`: [default: `true`] if options is a collection, yields the full model rather than just its `idAttribute` to `.value`
 
+When the collection changes, the view will try and maintain its currently `.value`.  If the corresponding model is removed, the <select> control will default to the 0th index <option> and update its value accordingly.
+
 ## custom template
 You may override the default template by providing your own template string to the [constructor](#constructor---function-new-selectviewoptions) options hash.  Technically, all you must provided is a `<select>` element.  However, your template may include the following under a single root element:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Alias to calling `setValue(null, true)`.  Sets the selected option to either the
 Sets the selected option and view value to the original option value provided during construction.
 
 ### setValue([value, skipValidationMessage]) - [Function] - returns `this`
-Sets the selected option to that which matches the provided value.  Updates the view's `.value` accordingly.  SelectView will error if no matching option exists.  `null, `undefined`, and `''` values will preferentially select [unselectedText](#general-options) if defined.
+Sets the selected option to that which matches the provided value.  Updates the view's `.value` accordingly.  SelectView will error if no matching option exists.  `null`, `undefined`, and `''` values will preferentially select [unselectedText](#general-options) if defined.
 
 ### constructor - [Function] `new SelectView([options])`
 #### options

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -42,6 +42,8 @@ function SelectView (opts) {
     this.startingValue = opts.value;
     this.yieldModel = (opts.yieldModel === false) ? false : true;
 
+    this.beforeSubmit = opts.beforeSubmit;
+    this.eagerValidate = opts.eagerValidate;
     this.required = opts.required || false;
     this.validClass = opts.validClass || 'input-valid';
     this.invalidClass = opts.invalidClass || 'input-invalid';
@@ -49,9 +51,9 @@ function SelectView (opts) {
 
     this.onChange = this.onChange.bind(this);
 
-    this.render();
+    this.startingValue = this.setValue(opts.value, this.eagerValidate ? false : true, true);
 
-    this.setValue(opts.value, opts.eagerValidate ? false : true);
+    this.render();
 }
 
 SelectView.prototype.render = function () {
@@ -85,12 +87,20 @@ SelectView.prototype.render = function () {
     this.updateSelectedOption();
 
     if (this.options.isCollection) {
-        this.options.on('add remove reset', function () {
+        this.options.on('add remove reset', function() {
+            var setValueFirstModel = function() {
+                if (!this.options.length) return;
+                if (this.yieldModel) this.setValue(this.options.models[0]);
+                else this.setValue(this.options.models[0][this.idAttribute]);
+            }.bind(this);
+
             this.renderOptions();
-            this.updateSelectedOption();
+            if (this.hasOptionByValue(this.value)) this.updateSelectedOption();
+            else setValueFirstModel();
         }.bind(this));
     }
 
+    this.validate(this.eagerValidate ? false : true, true);
     this.rendered = true;
 
     return this;
@@ -155,8 +165,12 @@ SelectView.prototype.updateSelectedOption = function () {
     var lookupValue = this.value;
 
     if (lookupValue === null || lookupValue === undefined || lookupValue === '') {
-        this.select.selectedIndex = 0;
-        return this;
+        if (this.unselectedText) {
+            this.select.selectedIndex = 0;
+            return this;
+        } else if (!this.options.length && this.value === null) {
+            return this;
+        }
     }
 
     // Pull out the id if it's a model
@@ -164,7 +178,8 @@ SelectView.prototype.updateSelectedOption = function () {
         lookupValue = lookupValue && lookupValue[this.idAttribute];
     }
 
-    if (lookupValue || lookupValue === 0) {
+    if (lookupValue || lookupValue === 0 || lookupValue === null) {
+        if (lookupValue === null) lookupValue = ''; // DOM sees only '' empty value
         for (var i = this.select.options.length; i--; i) {
             if (this.select.options[i].value == lookupValue) {
                 this.select.selectedIndex = i;
@@ -193,28 +208,52 @@ SelectView.prototype.clear = function() {
 };
 
 /**
- * Sets the selected option and view value to the original option value provided 
+ * Sets the selected option and view value to the original option value provided
  * during construction
  * @return {SelectView} this
  */
 SelectView.prototype.reset = function() {
-    if(this.startingValue !== undefined) this.setValue(this.startingValue, true);
-    return this;
+    return this.setValue(this.startingValue, true);
 };
 
-SelectView.prototype.setValue = function (value, skipValidationMessage) {
-    var option;
+SelectView.prototype.setValue = function (value, skipValidationMessage, init) {
+    var option, model, nullValid;
+
     if (value === null || value === undefined || value === '') {
         this.value = null;
+
+        // test if null is a valid option
+        if (this.unselectedText) {
+            nullValid = true;
+        } else {
+            nullValid = this.hasOptionByValue(null);
+        }
+
+        // empty value requested to be set.  This may be because the field is just
+        // initializing.  If initializing and `null` isn't in the honored option set
+        // set the select to the 0-th index
+        if (init && this.options.length && !nullValid) {
+            // no initial value passed, set initial value to first item in set
+            if (this.options.isCollection) {
+                model = this.options.models[0];
+                this.value = this.yieldModel ? model : model[this.idAttribute];
+            } else {
+                if (isArray(this.options[0])) {
+                    this.value = this.options[0][0];
+                } else {
+                    this.value = this.options[0];
+                }
+            }
+        }
     } else {
         // Ensure corresponding option exists before assigning value
         option = this.getOptionByValue(value);
         this.value = isArray(option) ? option[0] : option;
     }
     this.validate(skipValidationMessage);
-    this.updateSelectedOption();
+    if (this.select) this.updateSelectedOption();
     if (this.parent) this.parent.update(this);
-    return this;
+    return this.value;
 };
 
 SelectView.prototype.validate = function (skipValidationMessage) {
@@ -227,22 +266,21 @@ SelectView.prototype.validate = function (skipValidationMessage) {
 
     if (this.required && !this.value && this.value !== 0) {
         this.valid = false;
-        this.toggleMessage(skipValidationMessage, this.requiredMessage);
+        if (this.select) this.toggleMessage(skipValidationMessage, this.requiredMessage);
     } else {
         this.valid = true;
-        this.toggleMessage(skipValidationMessage);
+        if (this.select) this.toggleMessage(skipValidationMessage);
     }
 
     return this.valid;
 };
 
 /**
- * Called by FormView on submit 
+ * Called by FormView on submit
  * @return {SelectView} this
  */
 SelectView.prototype.beforeSubmit = function () {
     this.setValue(this.select.options[this.select.selectedIndex].value);
-    return this;
 };
 
 /**
@@ -256,6 +294,7 @@ SelectView.prototype.getOptionByValue = function(value) {
         // find value in collection, error if no model found
         if (this.options.indexOf(value) === -1) model = this.getModelForId(value);
         else model = value;
+        if (!model) throw new Error('model or model idAttribute not found in options collection');
         return this.yieldModel ? model : model[this.idAttribute];
     } else if (isArray(this.options)) {
         // find value value in options array
@@ -273,6 +312,23 @@ SelectView.prototype.getOptionByValue = function(value) {
 };
 
 
+
+/**
+ * Tests if option set has an option corresponding to the provided value
+ * @param  {*} value
+ * @return {Boolean}
+ */
+SelectView.prototype.hasOptionByValue = function(value) {
+    try {
+        this.getOptionByValue(value);
+        return true;
+    } catch (err) {
+        return false;
+    }
+};
+
+
+
 SelectView.prototype.getOptionValue = function (option) {
     if (Array.isArray(option)) return option[0];
     if (this.options.isCollection) return option[this.idAttribute];
@@ -281,9 +337,8 @@ SelectView.prototype.getOptionValue = function (option) {
 
 SelectView.prototype.getOptionText = function (option) {
     if (Array.isArray(option)) return option[1];
-
     if (this.options.isCollection) {
-        if (this.textAttribute && option[this.textAttribute]) {
+        if (this.textAttribute && option[this.textAttribute] !== undefined) {
             return option[this.textAttribute];
         }
     }
@@ -293,7 +348,6 @@ SelectView.prototype.getOptionText = function (option) {
 
 SelectView.prototype.getOptionDisabled = function (option) {
     if (Array.isArray(option)) return option[2];
-
     if (this.options.isCollection && this.disabledAttribute) return option[this.disabledAttribute];
 
     return false;
@@ -305,7 +359,7 @@ SelectView.prototype.toggleMessage = function (hide, message) {
 
     if (!mContainer || !mText) return;
 
-    if(hide) {
+    if (hide) {
         dom.hide(mContainer);
         mText.textContent = '';
         dom.removeClass(this.el, this.validClass);
@@ -330,7 +384,7 @@ function createOption (value, text, disabled) {
     var node = document.createElement('option');
 
     //Set to empty-string if undefined or null, but not if 0, false, etc
-    if (value === null || value === undefined) { value = ''; }
+    if (value === null || value === undefined) value = '';
 
     if(disabled) node.disabled = true;
     node.textContent = text;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -28,7 +28,7 @@ var BaseView = FormView.extend({
                 idAttribute: 'id',
                 textAttribute: 'title',
                 required: true,
-                unselectedText: 'show validation stuff when im selected after initial'
+                unselectedText: 'show validation text after initial interaction'
         });
 
         var requiredInvalidEager = window.requiredInvalidEager = new SelectView({
@@ -39,7 +39,7 @@ var BaseView = FormView.extend({
                 textAttribute: 'title',
                 required: true,
                 eagerValidate: true,
-                unselectedText: 'show validation stuff when im selected no matter what'
+                unselectedText: 'show validation text immediately'
         });
 
         return [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "ampersand-collection": "^1.3.1",
-    "ampersand-form-view": "^2.3.0",
+    "ampersand-form-view": "^3.1.0",
     "ampersand-state": "^4.4.5",
     "ampersand-view-conventions": "^1.1.1",
     "browserify": "^9.0.3",

--- a/test/index.js
+++ b/test/index.js
@@ -244,6 +244,22 @@ suite('Utility Methods', function (s) {
         t.equal(view.value, 'one');
     }));
 
+    s.test('reset on view where initial value missing', sync(function (t) {
+        var ops = [0, 1, 2];
+        view = new SelectView({
+            name: 'word',
+            options: ops,
+            value: 2
+        });
+        delete ops[2];
+        try {
+            view.reset();
+            t.ok(false, 'reset occurred without resetting view.value to view.startingValue');
+        } catch (err) {
+            t.ok(true, 'reset enforces that original value present in option set');
+        }
+    }));
+
     s.test('beforeSubmit', sync(function (t) {
         var called, formView;
         var formEl = document.createElement('form');

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var suite = require('tape-suite');
 var viewConventions = require('ampersand-view-conventions');
+var FormView = require('ampersand-form-view');
 var SelectView = require('../ampersand-select-view');
 var AmpersandState = require('ampersand-state');
 var AmpersandCollection = require('ampersand-collection');
@@ -142,8 +143,12 @@ suite('Utility Methods', function (s) {
         var select = view.el.querySelector('select');
 
         t.equal(select.options[select.selectedIndex].value, 'two');
-        view.clear();
-        t.equal(select.options[select.selectedIndex].value, 'one');
+        try {
+            view.clear();
+            t.ok(false, 'view cleared without null option');
+        } catch(err) {
+            t.ok(true, 'view unable to clear without null option');
+        }
     }));
 
     s.test('clear on view with `unselectedText`', sync(function (t) {
@@ -161,7 +166,6 @@ suite('Utility Methods', function (s) {
         view.clear();
         t.equal(select.options[select.selectedIndex].value, '');
         t.equal(select.options[select.selectedIndex].text, 'Please choose:');
-        view.validate();
         t.equal(view.valid, true);
     }));
 
@@ -176,10 +180,13 @@ suite('Utility Methods', function (s) {
         var select = view.el.querySelector('select');
 
         t.equal(select.options[select.selectedIndex].value, 'two');
-        view.clear();
-        t.equal(select.options[select.selectedIndex].value, 'one');
+        try {
+            view.clear();
+            t.ok(false, 'view cleared without null option');
+        } catch(err) {
+            t.ok(true, 'view unable to clear without null option');
+        }
         t.equal(view.value, null);
-        view.validate();
         t.equal(view.valid, false);
     }));
 
@@ -216,7 +223,7 @@ suite('Utility Methods', function (s) {
 
         view.setValue(2);
         t.equal(select.options[select.selectedIndex].value, '2');
-        
+
         view.reset();
         t.equal(view.value, 0);
     }));
@@ -233,25 +240,31 @@ suite('Utility Methods', function (s) {
         t.equal(select.options[select.selectedIndex].value, 'three');
 
         view.reset();
-        t.equal(select.options[select.selectedIndex].value, 'three');
-        t.equal(view.value, 'three');
+        t.equal(select.options[select.selectedIndex].value, 'one');
+        t.equal(view.value, 'one');
     }));
 
     s.test('beforeSubmit', sync(function (t) {
+        var called, formView;
+        var formEl = document.createElement('form');
         view = new SelectView({
             name: 'word',
             options: arr,
-            required: true
+            required: true,
+            beforeSubmit: function() {
+                called = true;
+            }
+        });
+        formView = new FormView({
+            el: formEl,
+            autoRender: true,
+            fields: [view]
         });
 
-        var select = view.el.querySelector('select');
-        t.equal(select.options[select.selectedIndex].value, 'one');
+        formView.beforeSubmit();
+        t.ok(called, 'beforeSubmit gets registered');
+        t.ok(view.valid, 'form is valid on form submit');
 
-        t.equal(view.valid, false);
-        t.equal(view.value, null);
-        view.beforeSubmit();
-        t.equal(view.value, 'one');
-        t.equal(view.valid, true);
     }));
 });
 
@@ -483,7 +496,7 @@ suite('With ampersand collection', function (s) {
         var coll = new Collection([
             { id: 1, someOtherKey: 'foo', title: 'Option one' },
             { id: 2, someOtherKey: 'bar', title: 'Option two' },
-            { id: 3, someOtherKey: 'baz', title: 'Option three' },
+            { id: 3, someOtherKey: 'baz', title: 'Option three' }
         ]);
 
         view = new SelectView({
@@ -494,21 +507,26 @@ suite('With ampersand collection', function (s) {
         });
 
         var optionNodes = view.el.querySelectorAll('select option');
-        t.equal(optionNodes.length, 3);
+        t.equal(optionNodes.length, 3, 'should have same #<option> nodes corresponding to collection models');
 
         coll.add({ id: 4, someOtherKey: 'four', title: 'Option four' });
+        optionNodes = view.el.querySelectorAll('select option');
+        t.equal(optionNodes.length, 4, 'should add <option> nodes when adding collection models');
 
         optionNodes = view.el.querySelectorAll('select option');
         t.equal(optionNodes.length, 4);
         t.equal(optionNodes[3].value, '4');
         t.equal(optionNodes[3].textContent, 'Option four');
 
+        t.equal(view.value, coll.models[0], 'default value should be first in collection');
         coll.remove({ id: 1 });
-
         optionNodes = view.el.querySelectorAll('select option');
-        t.equal(optionNodes.length, 3);
-        t.equal(optionNodes[0].value, '2');
-        t.equal(optionNodes[0].textContent, 'Option two');
+        t.equal(view.value, coll.models[0], 'should set value to first value in collection when current selected model removed');
+        t.equal(optionNodes.length, 3, 'option nodes should be reduced when model removed');
+
+        view.setValue(4);
+        coll.remove({ id: 2 });
+        t.equal(view.value, coll.get(4), 'should retain value if unassociated model removed');
 
         coll.reset([
             { id: 10, someOtherKey: 'bar', title: 'Option ten' },
@@ -567,6 +585,7 @@ suite('With ampersand collection', function (s) {
             { id: null, someOtherKey: 'bar', title: 'Option null' },
             { id: 2, someOtherKey: 'baz', title: 'Option two' },
         ]);
+
         view = new SelectView({
             name: 'testNullId',
             options: coll,
@@ -579,10 +598,10 @@ suite('With ampersand collection', function (s) {
         t.equal(optionNodes.length, 3);
 
         t.equal(optionNodes[0].value, '0', 'option before null model has correct value');
-        t.equal(optionNodes[0].textContent, 'Option zero');
+        t.equal(optionNodes[0].textContent, 'Option zero', 'selected option should be Option zero');
 
-        t.equal(view.value, null); // null option set by default when no value provided
-        t.equal(optionNodes[1].value, '');
+        t.equal(view.value, null, 'Option null should be selected with field value: null');
+        t.equal(optionNodes[1].value, '', 'selected option should be empty string');
 
         t.equal(optionNodes[2].value, '2', 'option after null model has correct value');
         t.equal(optionNodes[2].textContent, 'Option two');


### PR DESCRIPTION
Follow-up commits to #39.
- Fix README.md syntax
- make `beforeSubmit` extendable in view
- update collection behavior to try and first maintain existing `value`, otherwise, select 0th index
- adjust to support `render()`ing last, as `autoRender` false will soon need support
- update to support discussions in #39
- add and update a couple supporting tests
